### PR TITLE
[OK-398][feature] Bulk Deliver for AWS IoT

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,3 +22,6 @@ gem "apnotic", "~> 1.7"
 
 # firebase notifications
 gem "googleauth", "~> 1.1"
+
+# AWS IoT messages
+gem "aws-sdk-iotdataplane", "~> 1.75"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     noticed (2.4.3)
+      aws-sdk-iotdataplane (~> 1.75)
       rails (>= 6.1.0)
 
 GEM
@@ -87,6 +88,20 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
+    aws-eventstream (1.3.2)
+    aws-partitions (1.1109.0)
+    aws-sdk-core (3.224.1)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.992.0)
+      aws-sigv4 (~> 1.9)
+      base64
+      jmespath (~> 1, >= 1.6.1)
+      logger
+    aws-sdk-iotdataplane (1.75.0)
+      aws-sdk-core (~> 3, >= 3.216.0)
+      aws-sigv4 (~> 1.5)
+    aws-sigv4 (1.11.0)
+      aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.2.0)
     bigdecimal (3.1.8)
     builder (3.3.0)
@@ -124,6 +139,7 @@ GEM
     irb (1.14.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
+    jmespath (1.6.2)
     json (2.7.2)
     jwt (2.8.2)
       base64
@@ -140,6 +156,7 @@ GEM
       net-smtp
     marcel (1.0.4)
     mini_mime (1.1.5)
+    mini_portile2 (2.8.9)
     minitest (5.25.1)
     multi_json (1.15.0)
     net-http (0.4.1)
@@ -156,11 +173,8 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.3)
-    nokogiri (1.16.7-arm64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.16.7-x86_64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.16.7-x86_64-linux)
+    nokogiri (1.16.7)
+      mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     os (1.1.4)
     parallel (1.26.3)
@@ -240,9 +254,8 @@ GEM
       faraday (>= 0.17.5, < 3.a)
       jwt (>= 1.5, < 3.0)
       multi_json (~> 1.10)
-    sqlite3 (1.7.3-arm64-darwin)
-    sqlite3 (1.7.3-x86_64-darwin)
-    sqlite3 (1.7.3-x86_64-linux)
+    sqlite3 (1.7.3)
+      mini_portile2 (~> 2.8.0)
     standard (1.40.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
@@ -276,6 +289,7 @@ GEM
 PLATFORMS
   arm64-darwin-22
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-22
   x86_64-darwin-23
   x86_64-linux

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     noticed (2.4.3)
-      aws-sdk-iotdataplane (~> 1.75)
       rails (>= 6.1.0)
 
 GEM
@@ -297,6 +296,7 @@ PLATFORMS
 DEPENDENCIES
   apnotic (~> 1.7)
   appraisal
+  aws-sdk-iotdataplane (~> 1.75)
   googleauth (~> 1.1)
   noticed!
   pg

--- a/lib/noticed.rb
+++ b/lib/noticed.rb
@@ -20,10 +20,11 @@ module Noticed
   autoload :Translation, "noticed/translation"
 
   module BulkDeliveryMethods
+    autoload :AwsIot, "noticed/bulk_delivery_methods/aws_iot"
     autoload :Bluesky, "noticed/bulk_delivery_methods/bluesky"
+    autoload :ConfluentRestApi, "noticed/bulk_delivery_methods/confluent_rest_api"
     autoload :Discord, "noticed/bulk_delivery_methods/discord"
     autoload :KafkaRestProxy, "noticed/bulk_delivery_methods/kafka_rest_proxy"
-    autoload :ConfluentRestApi, "noticed/bulk_delivery_methods/confluent_rest_api"
     autoload :Slack, "noticed/bulk_delivery_methods/slack"
     autoload :Test, "noticed/bulk_delivery_methods/test"
     autoload :Webhook, "noticed/bulk_delivery_methods/webhook"

--- a/lib/noticed/bulk_delivery_methods/aws_iot.rb
+++ b/lib/noticed/bulk_delivery_methods/aws_iot.rb
@@ -3,31 +3,30 @@ require 'aws-sdk-iotdataplane'
 module Noticed
   module BulkDeliveryMethods
     class AwsIot < BulkDeliveryMethod
-      required_options :url, :credentials, :message
+      required_options :url, :region, :access_key_id, :secret_access_key, :topic, :payload, :qos, :retain
 
       def deliver
         url = evaluate_option(:url)
-        credentials = evaluate_option(:credentials)
-        message  = evaluate_option(:message)
+        region = evaluate_option(:region)
+        access_key_id = evaluate_option(:access_key_id)
+        secret_access_key = evaluate_option(:secret_access_key)
+        topic = evaluate_option(:topic)
+        payload = evaluate_option(:payload)
+        qos = evaluate_option(:qos)
+        retain = evaluate_option(:retain)
 
         client = Aws::IoTDataPlane::Client.new(
           endpoint: url,
-          region: credentials[:region],
-          credentials: Aws::Credentials.new(credentials[:access_key_id], credentials[:secret_access_key])
+          region: region,
+          credentials: Aws::Credentials.new(access_key_id, secret_access_key)
         )
 
         client.publish(
-          topic: message.fetch(:topic),
-          payload: serialise_payload(message.fetch(:payload)),
-          qos: message.fetch(:qos, 0),
-          retain: message.fetch(:retain, false)
+          topic: topic,
+          payload: payload,
+          qos: qos,
+          retain: retain
         )
-      end
-
-      private
-
-      def serialise_payload(payload)
-        payload.is_a?(String) ? payload : payload.to_json
       end
     end
   end

--- a/lib/noticed/bulk_delivery_methods/aws_iot.rb
+++ b/lib/noticed/bulk_delivery_methods/aws_iot.rb
@@ -1,0 +1,34 @@
+require 'aws-sdk-iotdataplane'
+
+module Noticed
+  module BulkDeliveryMethods
+    class AwsIot < BulkDeliveryMethod
+      required_options :url, :credentials, :message
+
+      def deliver
+        endpoint = evaluate_option(:url)
+        credentials = evaluate_option(:credentials).with_indifferent_access
+        message  = evaluate_option(:message)
+
+        client = Aws::IoTDataPlane::Client.new(
+          endpoint: endpoint,
+          region: credentials[:region],
+          credentials: Aws::Credentials.new(credentials[:access_key_id], credentials[:secret_access_key])
+        )
+
+        client.publish(
+          topic: message.fetch(:topic),
+          payload: serialise_payload(message.fetch(:payload)),
+          qos: message.fetch(:qos, 0),
+          retain: message.fetch(:retain, false)
+        )
+      end
+
+      private
+
+      def serialise_payload(payload)
+        payload.is_a?(String) ? payload : payload.to_json
+      end
+    end
+  end
+end

--- a/lib/noticed/bulk_delivery_methods/aws_iot.rb
+++ b/lib/noticed/bulk_delivery_methods/aws_iot.rb
@@ -7,7 +7,7 @@ module Noticed
 
       def deliver
         endpoint = evaluate_option(:url)
-        credentials = evaluate_option(:credentials).with_indifferent_access
+        credentials = evaluate_option(:credentials)
         message  = evaluate_option(:message)
 
         client = Aws::IoTDataPlane::Client.new(

--- a/lib/noticed/bulk_delivery_methods/aws_iot.rb
+++ b/lib/noticed/bulk_delivery_methods/aws_iot.rb
@@ -6,12 +6,12 @@ module Noticed
       required_options :url, :credentials, :message
 
       def deliver
-        endpoint = evaluate_option(:url)
+        url = evaluate_option(:url)
         credentials = evaluate_option(:credentials)
         message  = evaluate_option(:message)
 
         client = Aws::IoTDataPlane::Client.new(
-          endpoint: endpoint,
+          endpoint: url,
           region: credentials[:region],
           credentials: Aws::Credentials.new(credentials[:access_key_id], credentials[:secret_access_key])
         )

--- a/noticed.gemspec
+++ b/noticed.gemspec
@@ -17,4 +17,5 @@ Gem::Specification.new do |spec|
   spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
   spec.add_dependency "rails", ">= 6.1.0"
+  spec.add_dependency "aws-sdk-iotdataplane", "~> 1.75"
 end

--- a/noticed.gemspec
+++ b/noticed.gemspec
@@ -17,5 +17,4 @@ Gem::Specification.new do |spec|
   spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
   spec.add_dependency "rails", ">= 6.1.0"
-  spec.add_dependency "aws-sdk-iotdataplane", "~> 1.75"
 end

--- a/test/bulk_delivery_methods/aws_iot_test.rb
+++ b/test/bulk_delivery_methods/aws_iot_test.rb
@@ -1,0 +1,101 @@
+require "test_helper"
+
+class AwsIotBulkDeliveryMethodTest < ActiveSupport::TestCase
+  setup do
+    @delivery_method = Noticed::BulkDeliveryMethods::AwsIot.new
+  end
+
+  test "publishes to AWS IoT with correct options" do
+    mock_client = Minitest::Mock.new
+    mock_client.expect :publish, true do |**args|
+      assert_equal "nimble/orders", args[:topic]
+      assert_equal "{\"id\":123}", args[:payload]
+      assert_equal 1, args[:qos]
+      assert_equal true, args[:retain]
+    end
+
+    Aws::IoTDataPlane::Client.stub :new, mock_client do
+      set_config(
+        url: "https://test.iot.ap-southeast-2.amazonaws.com",
+        credentials: {
+          region: "ap-southeast-2",
+          access_key_id: "FAKEKEY",
+          secret_access_key: "FAKESECRET"
+        },
+        message: {
+          topic: "nimble/orders",
+          payload: { id: 123 },
+          qos: 1,
+          retain: true
+        }
+      )
+
+      assert_nothing_raised do
+        @delivery_method.deliver
+      end
+    end
+
+    mock_client.verify
+  end
+
+  test "uses default qos 0 and retain false when not set" do
+    mock_client = Minitest::Mock.new
+    mock_client.expect :publish, true do |**args|
+      assert_equal 0, args[:qos]
+      assert_equal false, args[:retain]
+    end
+
+    Aws::IoTDataPlane::Client.stub :new, mock_client do
+      set_config(
+        url: "https://test.iot.ap-southeast-2.amazonaws.com",
+        credentials: {
+          region: "ap-southeast-2",
+          access_key_id: "FAKEKEY",
+          secret_access_key: "FAKESECRET"
+        },
+        message: {
+          topic: "nimble/orders",
+          payload: { id: 123 }
+        }
+      )
+
+      assert_nothing_raised do
+        @delivery_method.deliver
+      end
+    end
+
+    mock_client.verify
+  end
+
+  test "does not double encode string payload" do
+    mock_client = Minitest::Mock.new
+    mock_client.expect :publish, true do |**args|
+      assert_equal "raw string", args[:payload]
+    end
+
+    Aws::IoTDataPlane::Client.stub :new, mock_client do
+      set_config(
+        url: "https://test.iot.ap-southeast-2.amazonaws.com",
+        credentials: {
+          region: "ap-southeast-2",
+          access_key_id: "FAKEKEY",
+          secret_access_key: "FAKESECRET"
+        },
+        message: {
+          topic: "nimble/orders",
+          payload: "raw string"
+        }
+      )
+
+      @delivery_method.deliver
+    end
+
+    mock_client.verify
+  end
+
+  private
+
+  def set_config(config)
+    @delivery_method.instance_variable_set :@config, ActiveSupport::HashWithIndifferentAccess.new(config)
+  end
+end


### PR DESCRIPTION
This PR introduces a new bulk delivery method for AWS IoT, allowing us to publish messages directly to AWS IoT Core.

This PR is required by https://github.com/okyaco/okya-web/pull/719